### PR TITLE
Compatibility with Ghidra 12 and missing instructions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,25 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+apply from: "$rootProject.projectDir/gradle/distributableGhidraModule.gradle"
+apply from: "$rootProject.projectDir/gradle/processorProject.gradle"
+apply plugin: 'eclipse'
+
+eclipse.project.name = 'Processors XAP2'
+
+sleighCompileOptions = [
+	'-x'
+]
+

--- a/data/languages/xap2.cspec
+++ b/data/languages/xap2.cspec
@@ -46,7 +46,7 @@
         <pentry minsize="1" maxsize="2">
           <register name="ah"/>
         </pentry>
-        <pentry minsize="3" maxsize="4" metatype="long">
+        <pentry minsize="3" maxsize="4">
           <register name="a"/>
         </pentry>
         <pentry minsize="1" maxsize="500" align="2">

--- a/data/languages/xap2.cspec
+++ b/data/languages/xap2.cspec
@@ -28,7 +28,7 @@
   </data_organization>
 
   <global>
-      <!--<range space="code"/>-->
+    <range space="code"/>
     <range space="mem"/>
   </global>
 

--- a/data/languages/xap2.slaspec
+++ b/data/languages/xap2.slaspec
@@ -130,6 +130,12 @@ macro csnzflags(op1, op2, value) {
 
 :nop is f_all=0 {}
 :sleep is f_opc=0 & f_right=8 & f_opnd=0 {}
+# Breakpoint
+:brk is f_opc=0 & f_right=4 & f_opnd=0 {}
+# Perform SIF (serial interface) cycle
+:sif is f_opc=0 & f_right=0xc & f_opnd=0 {}
+# Return from interrupt
+:rti is f_opc=0 & f_right=0xd {}
 
 :ld f_ld, data is f_opc=0 & f_ld & f_right=5 & data {
     f_ld = data;

--- a/data/languages/xap2.slaspec
+++ b/data/languages/xap2.slaspec
@@ -5,9 +5,15 @@ define space code     type=ram_space      size=3 wordsize=2 default;
 define space register type=register_space size=2;
 define space mem      type=ram_space      size=3 wordsize=2;
 
-define register offset=0x0 size=4 [ a x flags ];
-define register offset=0x0 size=2 [ ah al xh xl y pc lr ];
-define register offset=0x8 size=1 [ c s n z ];
+define register offset=0x0 size=4 [ a     x                   ];
+define register offset=0x0 size=2 [ ah al xh xl y pc lr flags ];
+
+define bitrange
+    z=flags[0,1]
+    n=flags[1,1]
+    c=flags[2,1]
+    s=flags[3,1]
+;
 
 define register offset=0x100 size=4 contextreg;
 
@@ -37,8 +43,8 @@ define token opc (16)
 
 attach variables [ f_reg ] [ ah al xl y ];
 attach variables [ f_mode ] [ _ _ xl y ];
-attach variables [ f_ld ] [ _ _ _ _ _ _ xl y _ _ _ _ _ _ xh _ ];
-attach variables [ f_st ] [ _ _ xl y _ _ _ _ _ _ xh _ _ _ _ _ ];
+attach variables [ f_ld ] [ _ _ _ _ _ flags xl y _ _ _ _ _ _ xh _ ];
+attach variables [ f_st ] [ _ flags xl y _ _ _ _ _ _ xh _ _ _ _ _ ];
 
 uimmval: val                is f_opnd & ext
 [ val = f_opnd + (ext << 8); ]
@@ -125,6 +131,10 @@ macro csnzflags(op1, op2, value) {
 :nop is f_all=0 {}
 :sleep is f_opc=0 & f_right=8 & f_opnd=0 {}
 
+:ld f_ld, data is f_opc=0 & f_ld & f_right=5 & data {
+    f_ld = data;
+}
+
 :ld f_ld, data is f_opc=0 & f_ld & f_mid=3 & data {
     f_ld = data;
     nzflags(f_ld);
@@ -133,6 +143,10 @@ macro csnzflags(op1, op2, value) {
 :ld f_reg, data is f_opc=1 & f_reg & data {
     f_reg = data;
     nzflags(f_reg);
+}
+
+:st f_st, data is f_opc=0 & f_right=1 & f_st & data {
+    f_st = data;
 }
 
 :st f_st, data is f_opc=0 & f_st & f_mid=1 & data {


### PR DESCRIPTION
- Ghidra 12 was choking on `metatype="long"` (https://github.com/SamL98/xap2/issues/1)
- uncomment `code` global space to enable decompiler
- add gradle build file
- add missing `ld flags, x` and `st flags, x` instruction parsing
- flags should use `bitrange`
- add missing `brk`, `sif` and `rti` instructions (they do nothing for now)

The disassembly of the missing instruction patterns was taken from https://github.com/rizinorg/rizin/blob/dev/librz/arch/isa/xap/dis.c